### PR TITLE
Fix share link slug handling

### DIFF
--- a/app/api/shares/route.ts
+++ b/app/api/shares/route.ts
@@ -6,8 +6,12 @@ export async function POST(req: NextRequest) {
   const body = await req.json()
   const { collection_id } = body || {}
   if (!collection_id) return NextResponse.json({ error: 'collection_id required' }, { status: 400 })
-  const { data, error } = await supabase.rpc('create_share_for_collection', { p_collection_id: collection_id })
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  const { data, error } = await supabase
+    .rpc('create_share_for_collection', { p_collection_id: collection_id })
+    .single<{ slug: string }>()
+  if (error || !data?.slug) {
+    return NextResponse.json({ error: error?.message || 'slug missing' }, { status: 500 })
+  }
   const url = `${process.env.NEXT_PUBLIC_SITE_URL || ''}/s/${data.slug}`
   return NextResponse.json({ slug: data.slug, url })
 }

--- a/app/ui/Dashboard.tsx
+++ b/app/ui/Dashboard.tsx
@@ -20,8 +20,7 @@ type Collection = {
   created_at?: string
 }
 
-type ShareResp = { 
-  url: string
+type ShareResp = {
   slug: string
 }
 
@@ -339,9 +338,10 @@ export default function Dashboard({ userId }: DashboardProps) {
 
       // Create public share
       const { data: share, error: sErr } = await supabase
-        .rpc('create_share_for_collection', { p_collection_id: collId }) as unknown as { data: ShareResp, error: any }
-      if (sErr) {
-        showError('خطأ في إنشاء رابط المشاركة: ' + sErr.message)
+        .rpc('create_share_for_collection', { p_collection_id: collId })
+        .single<ShareResp>()
+      if (sErr || !share?.slug) {
+        showError('خطأ في إنشاء رابط المشاركة' + (sErr ? ': ' + sErr.message : ''))
         return
       }
 


### PR DESCRIPTION
## Summary
- Ensure share creation returns a single row and validate slug before building URL
- Fix `/api/shares` to return slug correctly with improved error handling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_68a5de7203508321823774f7a8c133cb