### PR TITLE
Fix share page query for collection items

### DIFF
--- a/app/s/[slug]/page.tsx
+++ b/app/s/[slug]/page.tsx
@@ -23,7 +23,7 @@ export default function SharePage() {
       if (!s) { setLoading(false); return }
       const { data: its } = await supabase
         .from('collection_items')
-        .select('id,name,mimetype,size,path,collections!inner(id),collections(id,shares!inner(slug))')
+        .select('id,name,mimetype,size,path,collections!inner(id,shares!inner(slug))')
         .eq('collections.shares.slug', slug)
       const items = (its||[]).map((r:any)=>({ id: r.id, name: r.name, mimetype: r.mimetype, size: r.size, path: r.path }))
       // public urls


### PR DESCRIPTION
## Summary
- simplify the nested select on the share page to prevent a 400 response when loading shared files

## Testing
- `npm run lint` *(fails: interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e2737b6083218eb0147db29b9e00