### PR TITLE
feat: add share dialog with permission options

### DIFF
--- a/app/components/FileCard.tsx
+++ b/app/components/FileCard.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { File, Folder, CheckSquare, Square } from 'lucide-react'
+import { File, Folder, CheckSquare, Square, Share2 } from 'lucide-react'
 
 export type Item = {
   id: string
@@ -13,9 +13,9 @@ export type Item = {
 }
 
 export default function FileCard({
-  item, selected, toggle, onOpen
+  item, selected, toggle, onOpen, onShare
 }: {
-  item: Item, selected: boolean, toggle: ()=>void, onOpen: (it: Item)=>void
+  item: Item, selected: boolean, toggle: ()=>void, onOpen: (it: Item)=>void, onShare: (it: Item)=>void
 }) {
   const isImg = !!item.mimetype?.startsWith('image/')
   const isVid = !!item.mimetype?.startsWith('video/')
@@ -34,9 +34,14 @@ export default function FileCard({
       </div>
       <div className="flex items-center justify-between gap-2 mt-2">
         <button className="text-left text-sm truncate hover:underline" title={item.name} onClick={()=>onOpen(item)}>{item.name}</button>
-        <button className="opacity-80" onClick={toggle} title="تحديد">
-          {selected ? <CheckSquare className="w-4 h-4" /> : <Square className="w-4 h-4" />}
-        </button>
+        <div className="flex items-center gap-1">
+          <button className="opacity-80" onClick={()=>onShare(item)} title="مشاركة">
+            <Share2 className="w-4 h-4" />
+          </button>
+          <button className="opacity-80" onClick={toggle} title="تحديد">
+            {selected ? <CheckSquare className="w-4 h-4" /> : <Square className="w-4 h-4" />}
+          </button>
+        </div>
       </div>
       <div className="text-xs opacity-60 mt-1">{item.type==='file' && item.size ? Math.round(item.size/1024)+' KB' : ''}</div>
     </div>

--- a/app/components/ShareModal.tsx
+++ b/app/components/ShareModal.tsx
@@ -1,0 +1,40 @@
+'use client'
+import { useState, useEffect } from 'react'
+
+export default function ShareModal({ open, url, onClose }: { open: boolean, url: string, onClose: ()=>void }) {
+  const [mode, setMode] = useState<'view'|'edit'>('view')
+  const [copied, setCopied] = useState(false)
+
+  useEffect(()=>{ setMode('view'); setCopied(false) }, [url])
+
+  if (!open) return null
+
+  const link = mode === 'view' ? url : `${url}?mode=edit`
+  const copy = async () => {
+    try { await navigator.clipboard.writeText(link); setCopied(true) } catch { setCopied(false) }
+  }
+
+  return (
+    <div className="fixed inset-0 z-40 bg-black/60 grid place-items-center p-4">
+      <div className="card p-6 w-full max-w-md space-y-4">
+        <h3 className="text-xl font-bold">رابط المشاركة</h3>
+        <div className="space-y-2">
+          <label className="flex items-center gap-2">
+            <input type="radio" name="perm" checked={mode==='view'} onChange={()=>setMode('view')} /> معاينة فقط
+          </label>
+          <label className="flex items-center gap-2">
+            <input type="radio" name="perm" checked={mode==='edit'} onChange={()=>setMode('edit')} /> تعديل ومعاينة
+          </label>
+        </div>
+        <div className="space-y-2">
+          <input className="input w-full" readOnly value={link} />
+          <button className="btn" onClick={copy}>{copied? 'تم النسخ' : 'نسخ الرابط'}</button>
+        </div>
+        <div className="flex justify-end pt-2">
+          <button className="btn" onClick={onClose}>إغلاق</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/app/s/[slug]/page.tsx
+++ b/app/s/[slug]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useEffect, useMemo, useState } from 'react'
-import { useParams } from 'next/navigation'
+import { useParams, useSearchParams } from 'next/navigation'
 import { createClient } from '@/lib/supabaseClient'
 
 type Item = { id: string, name: string, mimetype: string | null, size: number | null, path: string, publicUrl?: string }
@@ -11,6 +11,8 @@ const BUCKET = 'drive'
 
 export default function SharePage() {
   const { slug } = useParams<{ slug: string }>()
+  const search = useSearchParams()
+  const canEdit = search.get('mode') === 'edit'
   const supabase = useMemo(()=>createClient(), [])
   const [share, setShare] = useState<Share|null>(null)
   const [items, setItems] = useState<Item[]>([])
@@ -78,6 +80,11 @@ export default function SharePage() {
             <div className="text-sm opacity-70">مشاركة</div>
             <h1 className="text-3xl md:text-4xl font-bold">{share.title || 'الملفات المشتركة'}</h1>
             {share.subtitle && <p className="opacity-80">{share.subtitle}</p>}
+            {canEdit ? (
+              <div className="text-sm text-green-400">لديك صلاحية التعديل</div>
+            ) : (
+              <div className="text-sm opacity-70">معاينة فقط</div>
+            )}
             {share.cta_label && share.cta_url && (
               <a href={share.cta_url} target="_blank" className="btn btn-primary inline-block">{share.cta_label}</a>
             )}


### PR DESCRIPTION
## Summary
- add modal to share files with view or edit permissions
- integrate share icon on files and in list view
- show permission info on shared pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a5eb9ff2108321bf9fe6db7f67bd68