### PR TITLE
feat: customize share page title and images

### DIFF
--- a/app/api/collections/route.ts
+++ b/app/api/collections/route.ts
@@ -11,8 +11,12 @@ export async function GET() {
 export async function POST(req: NextRequest) {
   const supabase = createClient()
   const body = await req.json()
-  const { name, title, subtitle, banner_image_url, cta_label, cta_url } = body || {}
-  const { data, error } = await supabase.from('collections').insert({ name, title, subtitle, banner_image_url, cta_label, cta_url }).select().single()
+  const { name, title, subtitle, banner_image_url, bottom_image_url, cta_label, cta_url } = body || {}
+  const { data, error } = await supabase
+    .from('collections')
+    .insert({ name, title, subtitle, banner_image_url, bottom_image_url, cta_label, cta_url })
+    .select()
+    .single()
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
   return NextResponse.json({ data })
 }

--- a/supadrive-pro-share-v1/supabase/migrations/2025-08-14_collections_shares.sql
+++ b/supadrive-pro-share-v1/supabase/migrations/2025-08-14_collections_shares.sql
@@ -6,6 +6,7 @@ create table if not exists public.collections (
   title text null,
   subtitle text null,
   banner_image_url text null,
+  bottom_image_url text null,
   cta_label text null,
   cta_url text null,
   created_at timestamp with time zone default now()
@@ -30,6 +31,7 @@ create table if not exists public.shares (
   title text null,
   subtitle text null,
   banner_image_url text null,
+  bottom_image_url text null,
   cta_label text null,
   cta_url text null,
   created_at timestamp with time zone default now()
@@ -88,4 +90,10 @@ with check (true);
 create policy if not exists "insert shares any"
 on public.shares for insert
 to authenticated, anon
+with check (true);
+
+create policy if not exists "update shares any"
+on public.shares for update
+to authenticated, anon
+using (true)
 with check (true);


### PR DESCRIPTION
## Summary
- allow setting main share title instead of fixed 'الملفات المشتركة'
- add inputs to upload promotional and footer images on share page
- store new footer image field in database and enable share updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt requires configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a60ad8897c8321b22ae1fb46602a5f