### PR TITLE
feat: customize share dialog with title and images

### DIFF
--- a/app/api/collections/route.ts
+++ b/app/api/collections/route.ts
@@ -11,8 +11,12 @@ export async function GET() {
 export async function POST(req: NextRequest) {
   const supabase = createClient()
   const body = await req.json()
-  const { name, title, subtitle, banner_image_url, cta_label, cta_url } = body || {}
-  const { data, error } = await supabase.from('collections').insert({ name, title, subtitle, banner_image_url, cta_label, cta_url }).select().single()
+  const { name, title, subtitle, banner_image_url, bottom_image_url, cta_label, cta_url } = body || {}
+  const { data, error } = await supabase
+    .from('collections')
+    .insert({ name, title, subtitle, banner_image_url, bottom_image_url, cta_label, cta_url })
+    .select()
+    .single()
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
   return NextResponse.json({ data })
 }

--- a/app/components/ShareModal.tsx
+++ b/app/components/ShareModal.tsx
@@ -1,11 +1,60 @@
 'use client'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo, ChangeEvent } from 'react'
+import { createClient } from '@/lib/supabaseClient'
 
 export default function ShareModal({ open, url, onClose }: { open: boolean, url: string, onClose: ()=>void }) {
   const [mode, setMode] = useState<'view'|'edit'>('view')
   const [copied, setCopied] = useState(false)
+  const [share, setShare] = useState<any>(null)
+  const [title, setTitle] = useState('')
+  const supabase = useMemo(() => createClient(), [])
+  const slug = useMemo(() => {
+    try {
+      return new URL(url).pathname.split('/').pop() || ''
+    } catch {
+      return ''
+    }
+  }, [url])
 
   useEffect(()=>{ setMode('view'); setCopied(false) }, [url])
+
+  useEffect(() => {
+    if (!open || !slug) return
+    const load = async () => {
+      const { data } = await supabase.from('shares').select('*').eq('slug', slug).single()
+      setShare(data)
+      setTitle(data?.title || '')
+    }
+    load()
+  }, [open, slug, supabase])
+
+  const updateShare = async (fields: any) => {
+    if (!share) return
+    const { data, error } = await supabase.from('shares').update(fields).eq('id', share.id).select().single()
+    if (!error && data) setShare(data)
+  }
+
+  const saveTitle = async () => {
+    await updateShare({ title })
+  }
+
+  const uploadImage = async (file: File, field: 'banner_image_url' | 'bottom_image_url') => {
+    if (!slug) return
+    const target = `public/${slug}-${field}-${file.name}`
+    await supabase.storage.from('drive').upload(target, file, { upsert: true })
+    const { data } = supabase.storage.from('drive').getPublicUrl(target)
+    await updateShare({ [field]: data.publicUrl })
+  }
+
+  const onBannerChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) uploadImage(file, 'banner_image_url')
+  }
+
+  const onBottomChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) uploadImage(file, 'bottom_image_url')
+  }
 
   if (!open) return null
 
@@ -18,6 +67,21 @@ export default function ShareModal({ open, url, onClose }: { open: boolean, url:
     <div className="fixed inset-0 z-40 bg-black/60 grid place-items-center p-4">
       <div className="card p-6 w-full max-w-md space-y-4">
         <h3 className="text-xl font-bold">رابط المشاركة</h3>
+        <div className="space-y-4">
+          <div>
+            <label className="block mb-1 text-sm">العنوان الرئيسي</label>
+            <input className="input w-full" value={title} onChange={e=>setTitle(e.target.value)} />
+            <button className="btn mt-2" onClick={saveTitle}>حفظ</button>
+          </div>
+          <div>
+            <label className="block mb-1 text-sm">الصورة الإعلانية</label>
+            <input type="file" accept="image/*" onChange={onBannerChange} />
+          </div>
+          <div>
+            <label className="block mb-1 text-sm">صورة أسفل الصفحة</label>
+            <input type="file" accept="image/*" onChange={onBottomChange} />
+          </div>
+        </div>
         <div className="space-y-2">
           <label className="flex items-center gap-2">
             <input type="radio" name="perm" checked={mode==='view'} onChange={()=>setMode('view')} /> معاينة فقط

--- a/app/s/[slug]/page.tsx
+++ b/app/s/[slug]/page.tsx
@@ -7,7 +7,17 @@ import { saveAs } from 'file-saver'
 import JSZip from 'jszip'
 
 type Item = { id: string, name: string, mimetype: string | null, size: number | null, path: string, publicUrl?: string }
-type Share = { id: string, slug: string, collection_id: string, title: string | null, subtitle: string | null, banner_image_url: string | null, cta_label: string | null, cta_url: string | null }
+type Share = {
+  id: string,
+  slug: string,
+  collection_id: string,
+  title: string | null,
+  subtitle: string | null,
+  banner_image_url: string | null,
+  bottom_image_url: string | null,
+  cta_label: string | null,
+  cta_url: string | null
+}
 type DisplayItem = { id: string, name: string, type: 'folder' } | (Item & { type: 'file' })
 
 const BUCKET = 'drive'
@@ -147,7 +157,7 @@ export default function SharePage() {
         <div className="container mx-auto p-6 grid md:grid-cols-12 gap-6 items-center">
           <div className="md:col-span-7 space-y-3">
             <div className="text-sm opacity-70">مشاركة</div>
-            <h1 className="text-3xl md:text-4xl font-bold">{share.title || 'الملفات المشتركة'}</h1>
+            <h1 className="text-3xl md:text-4xl font-bold">{share.title || ''}</h1>
             {share.subtitle && <p className="opacity-80">{share.subtitle}</p>}
             {canEdit ? (
               <div className="text-sm text-green-400">لديك صلاحية التعديل</div>
@@ -211,6 +221,11 @@ export default function SharePage() {
           ))}
         </div>
       </main>
+      {share.bottom_image_url && (
+        <div className="container mx-auto p-6">
+          <img src={share.bottom_image_url} alt="bottom" className="w-full object-cover rounded-xl" />
+        </div>
+      )}
     </div>
   )
 }

--- a/supadrive-pro-share-v1/supabase/migrations/2025-08-14_collections_shares.sql
+++ b/supadrive-pro-share-v1/supabase/migrations/2025-08-14_collections_shares.sql
@@ -6,6 +6,7 @@ create table if not exists public.collections (
   title text null,
   subtitle text null,
   banner_image_url text null,
+  bottom_image_url text null,
   cta_label text null,
   cta_url text null,
   created_at timestamp with time zone default now()
@@ -30,6 +31,7 @@ create table if not exists public.shares (
   title text null,
   subtitle text null,
   banner_image_url text null,
+  bottom_image_url text null,
   cta_label text null,
   cta_url text null,
   created_at timestamp with time zone default now()
@@ -88,4 +90,10 @@ with check (true);
 create policy if not exists "insert shares any"
 on public.shares for insert
 to authenticated, anon
+with check (true);
+
+create policy if not exists "update shares any"
+on public.shares for update
+to authenticated, anon
+using (true)
 with check (true);


### PR DESCRIPTION
## Summary
- move share title and image settings into share dialog
- simplify shared page by removing metadata editing inputs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires ESLint configuration via interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a60ad8897c8321b22ae1fb46602a5f