### PR TITLE
feat: use email OTP auth and dynamic share links

### DIFF
--- a/app/api/shares/route.ts
+++ b/app/api/shares/route.ts
@@ -12,6 +12,7 @@ export async function POST(req: NextRequest) {
   if (error || !data?.slug) {
     return NextResponse.json({ error: error?.message || 'slug missing' }, { status: 500 })
   }
-  const url = `${process.env.NEXT_PUBLIC_SITE_URL || ''}/s/${data.slug}`
+  const origin = process.env.NEXT_PUBLIC_SITE_URL || new URL(req.url).origin
+  const url = `${origin}/s/${data.slug}`
   return NextResponse.json({ slug: data.slug, url })
 }

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,31 +1,23 @@
 'use client'
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabaseClient'
 
-export default function LoginPage() {
+export default function RegisterPage() {
   const supabase = createClient()
   const router = useRouter()
-  const [email, setEmail] = useState('')
+  const searchParams = useSearchParams()
+  const initial = searchParams.get('email') || ''
+  const [email, setEmail] = useState(initial)
   const [sent, setSent] = useState(false)
   const [code, setCode] = useState('')
 
   const handleSend = async (e: React.FormEvent) => {
     e.preventDefault()
-    const { error } = await supabase.auth.signInWithOtp({
-      email,
-      options: { shouldCreateUser: false }
-    })
-    if (error) {
-      if (error.message.toLowerCase().includes('user not found')) {
-        router.push(`/register?email=${encodeURIComponent(email)}`)
-      } else {
-        alert(error.message)
-      }
-    } else {
-      setSent(true)
-    }
+    const { error } = await supabase.auth.signInWithOtp({ email })
+    if (error) alert(error.message)
+    else setSent(true)
   }
 
   const handleVerify = async (e: React.FormEvent) => {
@@ -42,7 +34,7 @@ export default function LoginPage() {
   return (
     <div className="min-h-screen grid place-items-center p-8">
       <div className="card p-10 w-full max-w-md space-y-6">
-        <h1 className="text-2xl font-bold">تسجيل الدخول</h1>
+        <h1 className="text-2xl font-bold">التسجيل</h1>
         {sent ? (
           <form onSubmit={handleVerify} className="space-y-3">
             <input
@@ -54,7 +46,7 @@ export default function LoginPage() {
               required
             />
             <button className="btn btn-primary w-full" type="submit">
-              دخول
+              تفعيل
             </button>
           </form>
         ) : (
@@ -73,7 +65,7 @@ export default function LoginPage() {
           </form>
         )}
         <p className="text-sm opacity-80">
-          لا تملك حساباً؟ <Link className="link" href="/register">سجّل الآن</Link>
+          لديك حساب؟ <Link className="link" href="/login">سجّل الدخول</Link>
         </p>
       </div>
     </div>

--- a/app/ui/Dashboard.tsx
+++ b/app/ui/Dashboard.tsx
@@ -393,7 +393,8 @@ export default function Dashboard({ userId }: DashboardProps) {
         return
       }
 
-      const url = `${window.location.origin}/s/${share.slug}`
+      const base = process.env.NEXT_PUBLIC_SITE_URL || window.location.origin
+      const url = `${base}/s/${share.slug}`
       setShareUrl(url)
       setShareOpen(true)
       setSelected({})


### PR DESCRIPTION
## Summary
- replace magic-link login with email OTP and redirect unregistered users to a new sign-up page
- allow new users to register via OTP
- generate share links using configured site URL or current origin
- use Next.js Link for auth page navigation and derive share origin from request URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: requires Supabase project URL and API key)*

------
https://chatgpt.com/codex/tasks/task_e_68a975684c908321971b16bc563ce15c