### PR TITLE
Wrap register page search params in Suspense

### DIFF
--- a/app/api/shares/route.ts
+++ b/app/api/shares/route.ts
@@ -12,7 +12,6 @@ export async function POST(req: NextRequest) {
   if (error || !data?.slug) {
     return NextResponse.json({ error: error?.message || 'slug missing' }, { status: 500 })
   }
-  const origin = process.env.NEXT_PUBLIC_SITE_URL || new URL(req.url).origin
   const origin = process.env.NEXT_PUBLIC_SITE_URL || req.headers.get('origin') || ''
   const url = `${origin}/s/${data.slug}`
   return NextResponse.json({ slug: data.slug, url })

--- a/app/register/RegisterForm.tsx
+++ b/app/register/RegisterForm.tsx
@@ -1,0 +1,73 @@
+'use client'
+import { useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { createClient } from '@/lib/supabaseClient'
+
+export default function RegisterForm() {
+  const supabase = createClient()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const initial = searchParams.get('email') || ''
+  const [email, setEmail] = useState(initial)
+  const [sent, setSent] = useState(false)
+  const [code, setCode] = useState('')
+
+  const handleSend = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { error } = await supabase.auth.signInWithOtp({ email })
+    if (error) alert(error.message)
+    else setSent(true)
+  }
+
+  const handleVerify = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { error } = await supabase.auth.verifyOtp({
+      email,
+      token: code,
+      type: 'email'
+    })
+    if (error) alert(error.message)
+    else router.push('/')
+  }
+
+  return (
+    <div className="min-h-screen grid place-items-center p-8">
+      <div className="card p-10 w-full max-w-md space-y-6">
+        <h1 className="text-2xl font-bold">التسجيل</h1>
+        {sent ? (
+          <form onSubmit={handleVerify} className="space-y-3">
+            <input
+              className="input"
+              type="text"
+              placeholder="رمز التحقق"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              required
+            />
+            <button className="btn btn-primary w-full" type="submit">
+              تفعيل
+            </button>
+          </form>
+        ) : (
+          <form onSubmit={handleSend} className="space-y-3">
+            <input
+              className="input"
+              type="email"
+              placeholder="your@email.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+            <button className="btn btn-primary w-full" type="submit">
+              إرسال الرمز
+            </button>
+          </form>
+        )}
+        <p className="text-sm opacity-80">
+          لديك حساب؟ <a className="link" href="/login">سجّل الدخول</a>
+        </p>
+      </div>
+    </div>
+  )
+}
+

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,74 +1,11 @@
-'use client'
-import { useState } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
-import Link from 'next/link'
-import { createClient } from '@/lib/supabaseClient'
+import { Suspense } from 'react'
+import RegisterForm from './RegisterForm'
 
 export default function RegisterPage() {
-  const supabase = createClient()
-  const router = useRouter()
-  const searchParams = useSearchParams()
-  const initial = searchParams.get('email') || ''
-  const [email, setEmail] = useState(initial)
-  const [sent, setSent] = useState(false)
-  const [code, setCode] = useState('')
-
-  const handleSend = async (e: React.FormEvent) => {
-    e.preventDefault()
-    const { error } = await supabase.auth.signInWithOtp({ email })
-    if (error) alert(error.message)
-    else setSent(true)
-  }
-
-  const handleVerify = async (e: React.FormEvent) => {
-    e.preventDefault()
-    const { error } = await supabase.auth.verifyOtp({
-      email,
-      token: code,
-      type: 'email'
-    })
-    if (error) alert(error.message)
-    else router.push('/')
-  }
-
   return (
-    <div className="min-h-screen grid place-items-center p-8">
-      <div className="card p-10 w-full max-w-md space-y-6">
-        <h1 className="text-2xl font-bold">التسجيل</h1>
-        {sent ? (
-          <form onSubmit={handleVerify} className="space-y-3">
-            <input
-              className="input"
-              type="text"
-              placeholder="رمز التحقق"
-              value={code}
-              onChange={(e) => setCode(e.target.value)}
-              required
-            />
-            <button className="btn btn-primary w-full" type="submit">
-              تفعيل
-            </button>
-          </form>
-        ) : (
-          <form onSubmit={handleSend} className="space-y-3">
-            <input
-              className="input"
-              type="email"
-              placeholder="your@email.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-            />
-            <button className="btn btn-primary w-full" type="submit">
-              إرسال الرمز
-            </button>
-          </form>
-        )}
-        <p className="text-sm opacity-80">
-          لديك حساب؟ <a className="link" href="/login">سجّل الدخول</a>
-        </p>
-      </div>
-    </div>
+    <Suspense fallback={<div>Loading...</div>}>
+      <RegisterForm />
+    </Suspense>
   )
 }
 


### PR DESCRIPTION
## Summary
- wrap `/register` page content in a Suspense boundary
- move registration form to a client component using `useSearchParams`
- fix duplicate `origin` variable in share API route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run build` *(fails: Supabase project URL/API key required)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d258d4b08321b3f4c2aebb012c78